### PR TITLE
Update org.kde.Platform from 5.15-21.08 to 5.15-23.08

### DIFF
--- a/com.sweetscape.ZeroOneZeroEditor.yml
+++ b/com.sweetscape.ZeroOneZeroEditor.yml
@@ -1,6 +1,6 @@
 app-id: com.sweetscape.ZeroOneZeroEditor
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-23.08
 sdk: org.kde.Sdk
 command: 010editor
 finish-args:


### PR DESCRIPTION
5.15-21.08 is at end of life and it prevents some packages from being updated like `org.freedesktop.Platform.VAAPI.Intel` `org.freedesktop.Platform.GL.default` using more space in the system.

```
Info: runtime org.kde.Platform branch 5.15-21.08 is end-of-life, with reason:
   We strongly recommend moving to the latest stable version of the Platform and SDK
Info: applications using this runtime:
   com.sweetscape.ZeroOneZeroEditor

Info: runtime org.freedesktop.Platform.VAAPI.Intel branch 21.08 is end-of-life, with reason:
   org.freedesktop.Platform 21.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
Info: applications using this runtime:
   com.sweetscape.ZeroOneZeroEditor

Info: runtime org.freedesktop.Platform.GL.default branch 21.08 is end-of-life, with reason:
   org.freedesktop.Platform 21.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
Info: applications using this runtime:
   com.sweetscape.ZeroOneZeroEditor
   ```