### PR TITLE
Update Exec command to accept file arguments

### DIFF
--- a/com.sweetscape.ZeroOneZeroEditor.desktop
+++ b/com.sweetscape.ZeroOneZeroEditor.desktop
@@ -4,6 +4,6 @@ Encoding=UTF-8
 Name=010 Editor
 GenericName=A text and hex edtior
 Type=Application
-Exec=010editor
+Exec=010editor %f
 Icon=com.sweetscape.ZeroOneZeroEditor
 


### PR DESCRIPTION
Updated the `Exec` command in `com.sweetscape.ZeroOneZeroEditor.desktop` to accept a file argument (`%f`), allowing users to open files directly with `010 Editor` from the file manager. This is also the behaviour of the official desktop file created by `010editor -install`.